### PR TITLE
Add checks that raise colored flags when conditions are not met (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 .env
 .idea
 __pycache__
+*.pyc

--- a/dbqueries.py
+++ b/dbqueries.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+import pytz
+
 QUERIES = {
     'number_of_courses_by_term': {
-        'index': 'term',
         'output_file_name': 'number_of_courses_by_term.csv',
         'data_source': 'UDW',
         'query_name': 'UDW Course Counts by Term',
@@ -17,20 +19,26 @@ QUERIES = {
             ORDER BY REGEXP_SUBSTR(term, '^\\\\D+') DESC,
             NULLIF(REGEXP_SUBSTR(term, '.+', REGEXP_INSTR(term, '\\\\d+')+4), '') ASC NULLS FIRST, 
                 REGEXP_SUBSTR(term, '\\\\d+') DESC;
-        """
+        """,
+        'checks': {}
     },
     'unizin_metadata': {
-        'index': '',
         'output_file_name': 'unizin_metadata.csv',
         'data_source': 'UDW',
         'query_name': 'Unizin Metadata',
         'type': 'standard',
         'query': """
             SELECT * FROM unizin_metadata;
-        """
+        """,
+        'checks': {
+            'less_than_two_days': {
+                'level': 'yellow',
+                'condition': (lambda x: (datetime.now(tz=pytz.UTC) - datetime.fromisoformat(x)).days < 2),
+                'rows_to_ignore': [0]
+            }
+        }
     },
     'udw_table_counts': {
-        'index': '',
         'output_file_name': 'udw_table_counts.csv',
         'data_source': 'UDW',
         'query_name': 'UDW Table Record Counts',
@@ -45,6 +53,13 @@ QUERIES = {
             'SUBMISSION_DIM',
             'SUBMISSION_FACT',
             'USER_DIM',
-        ]
+        ],
+        'checks': {
+            'not_zero': {
+                'level': 'red',
+                'condition': (lambda x: x != 0),
+                'rows_to_ignore': []
+            }
+        }
     }
 }

--- a/dbqueries.py
+++ b/dbqueries.py
@@ -32,7 +32,7 @@ QUERIES = {
         """,
         'checks': {
             'less_than_two_days': {
-                'color': 'yellow',
+                'color': 'YELLOW',
                 'condition': (lambda x: (datetime.now(tz=pytz.UTC) - datetime.fromisoformat(x)).days < 2),
                 'rows_to_ignore': [0]
             }
@@ -56,7 +56,7 @@ QUERIES = {
         ],
         'checks': {
             'not_zero': {
-                'color': 'red',
+                'color': 'RED',
                 'condition': (lambda x: x != 0),
                 'rows_to_ignore': []
             }

--- a/dbqueries.py
+++ b/dbqueries.py
@@ -34,7 +34,7 @@ QUERIES = {
             'less_than_two_days': {
                 'color': 'YELLOW',
                 'condition': (lambda x: (datetime.now(tz=pytz.UTC) - datetime.fromisoformat(x)).days < 2),
-                'rows_to_ignore': [0]
+                'rows_to_ignore': ['schemaversion']
             }
         }
     },

--- a/dbqueries.py
+++ b/dbqueries.py
@@ -32,7 +32,7 @@ QUERIES = {
         """,
         'checks': {
             'less_than_two_days': {
-                'level': 'yellow',
+                'color': 'yellow',
                 'condition': (lambda x: (datetime.now(tz=pytz.UTC) - datetime.fromisoformat(x)).days < 2),
                 'rows_to_ignore': [0]
             }
@@ -56,7 +56,7 @@ QUERIES = {
         ],
         'checks': {
             'not_zero': {
-                'level': 'red',
+                'color': 'red',
                 'condition': (lambda x: x != 0),
                 'rows_to_ignore': []
             }

--- a/test.py
+++ b/test.py
@@ -1,0 +1,70 @@
+# local modules
+from dbqueries import QUERIES
+import validate
+
+# standard modules
+from datetime import datetime, timedelta
+import pandas as pd
+import pytz
+import unittest
+
+
+class TestFlagRaising(unittest.TestCase):
+
+    def test_udw_table_counts_check(self):
+        # Set up
+        udw_table_counts_df = pd.DataFrame({
+            'table_name': [
+                'ASSIGNMENT_DIM',
+                'COURSE_DIM',
+                'COURSE_SCORE_FACT',
+                'ENROLLMENT_TERM_DIM',
+                'PSEUDONYM_DIM',
+                'SUBMISSION_COMMENT_DIM',
+                'SUBMISSION_DIM',
+                'SUBMISSION_FACT',
+                'USER_DIM',
+            ],
+            'record_count': [1000, 1000, 1000, 0, 1000, 1000, 1000, 1000, 0]
+        })
+        query_dict = QUERIES['udw_table_counts']
+        # Test
+        checks_result = validate.run_checks_on_output(query_dict['checks'], udw_table_counts_df)
+        self.assertCountEqual(
+            ['table_name', 'record_count', 'not_zero'],
+            checks_result.checked_output_df.columns.to_list()
+        )
+        self.assertTrue(checks_result.red_flag_raised)
+        self.assertFalse(checks_result.yellow_flag_raised)
+        result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
+        self.assertEqual(result_text.count('<-- "not_zero" condition failed'), 2)
+        print(result_text)
+
+    def test_unizin_metadata_check(self):
+        # Set up
+        delta_obj = timedelta(days=-3)
+        three_days_ago = datetime.now(tz=pytz.UTC) + delta_obj
+        unizin_metadata_df = pd.DataFrame({
+            'key': ['schemaversion', 'canvasdatadate'],
+            'value': ['X.X.X', three_days_ago.isoformat()]
+        })
+        query_dict = QUERIES['unizin_metadata']
+        # Test
+        checks_result = validate.run_checks_on_output(query_dict['checks'], unizin_metadata_df)
+        self.assertCountEqual(
+            ['key', 'value', 'less_than_two_days'],
+            checks_result.checked_output_df.columns.to_list()
+        )
+        self.assertFalse(checks_result.red_flag_raised)
+        self.assertTrue(checks_result.yellow_flag_raised)
+        result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
+        self.assertIn('<-- "less_than_two_days" condition failed', result_text)
+        print(result_text)
+
+
+unittest.main()
+
+
+
+
+

--- a/test.py
+++ b/test.py
@@ -34,11 +34,9 @@ class TestFlagRaising(unittest.TestCase):
             ['table_name', 'record_count', 'not_zero'],
             checks_result.checked_output_df.columns.to_list()
         )
-        self.assertTrue(checks_result.red_flag_raised)
-        self.assertFalse(checks_result.yellow_flag_raised)
+        self.assertTrue(checks_result.flags == ["RED"])
         result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
         self.assertEqual(result_text.count('<-- "not_zero" condition failed'), 2)
-        print(result_text)
 
     def test_unizin_metadata_check(self):
         # Set up
@@ -55,16 +53,9 @@ class TestFlagRaising(unittest.TestCase):
             ['key', 'value', 'less_than_two_days'],
             checks_result.checked_output_df.columns.to_list()
         )
-        self.assertFalse(checks_result.red_flag_raised)
-        self.assertTrue(checks_result.yellow_flag_raised)
+        self.assertTrue(checks_result.flags == ["YELLOW"])
         result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
         self.assertIn('<-- "less_than_two_days" condition failed', result_text)
-        print(result_text)
 
 
 unittest.main()
-
-
-
-
-

--- a/validate.py
+++ b/validate.py
@@ -86,7 +86,9 @@ def run_checks_on_output(checks_dict, output_df):
         check_func = check['condition']
         output_df[check_name] = output_df.iloc[:, 1]
         if len(check['rows_to_ignore']) > 0:
-            output_df[check_name][check['rows_to_ignore']] = np.nan
+            first_column = output_df.columns[0]
+            row_indexes_to_ignore = output_df[output_df[first_column].isin(check['rows_to_ignore'])].index.to_list()
+            output_df[check_name][row_indexes_to_ignore] = np.nan
         output_df[check_name] = output_df[check_name].map(check_func, na_action='ignore')
         if False in output_df[check_name].to_list():
             logger.info(f"Raising {check['color']} flag")
@@ -130,9 +132,9 @@ def email_results(subject, results_text_string):
     msg['Precedence'] = 'list'
 
     logger.info(f"Emailing out results to {msg['To']}")
-    server = smtplib.SMTP(ENV.get("SMTP_HOST"), ENV.get("SMTP_PORT"), None, 5)
-    server.send_message(msg)
-    server.quit()
+    # server = smtplib.SMTP(ENV.get("SMTP_HOST"), ENV.get("SMTP_PORT"), None, 5)
+    # server.send_message(msg)
+    # server.quit()
 
 
 # Main Program

--- a/validate.py
+++ b/validate.py
@@ -132,9 +132,9 @@ def email_results(subject, results_text_string):
     msg['Precedence'] = 'list'
 
     logger.info(f"Emailing out results to {msg['To']}")
-    # server = smtplib.SMTP(ENV.get("SMTP_HOST"), ENV.get("SMTP_PORT"), None, 5)
-    # server.send_message(msg)
-    # server.quit()
+    server = smtplib.SMTP(ENV.get("SMTP_HOST"), ENV.get("SMTP_PORT"), None, 5)
+    server.send_message(msg)
+    server.quit()
 
 
 # Main Program

--- a/validate.py
+++ b/validate.py
@@ -89,12 +89,8 @@ def run_checks_on_output(checks_dict, output_df):
             output_df[check_name][check['rows_to_ignore']] = np.nan
         output_df[check_name] = output_df[check_name].map(check_func, na_action='ignore')
         if False in output_df[check_name].to_list():
-            if checks_dict[check_name]['color'] == 'red':
-                logger.info("Raising red flag")
-                flag_strings.append("RED")
-            elif checks_dict[check_name]['color'] == 'yellow':
-                logger.info("Raising yellow flag")
-                flag_strings.append("YELLOW")
+            logger.info(f"Raising {check['color']} flag")
+            flag_strings.append(check['color'])
     checked_output_df = output_df
     ChecksResult = namedtuple("ChecksResult", ["checked_output_df", "flags"])
     return ChecksResult(checked_output_df, flag_strings)


### PR DESCRIPTION
This PR adds new features to both `validate.py` and `dbqueries.py` that determine the proper exit code and format the plain text output based on the results of checks performed on query results. In addition, a test module with two test was added to ensure concerning results are flagged and labeled accordingly. More details will be provided below. The PR aims to resolve issue #8.

1) Our previous discussion about the validation work suggested that we wanted to both make the approach extensible and differentiate between results that were merely concerning and those that would want us to cancel other scheduled processes. With that in mind, I decided to embed the details about checks into `dbqueries.py`. Within each `query` dictionary, I added a `checks` dictionary containing `color`, `condition` and `rows_to_ignore` keys. `color` is designed to have as its value either `YELLOW` or `RED` depending on whether a check failure should only trigger a warning or stop a process, respectively. `condition` should have its value a lambda function resulting in `True` if the check passes and `False` otherwise. `rows_to_ignore` should be a list of indexes for rows not relevant to the check (e.g. `schemaversion` for the `less_than_two_days` check`).

2) I then refactored existing code in `validate` to create two new functions: `run_checks_on_output` and `generate_results_text`. I thought it would make the code cleaner to separate these steps, but I will admit the decision was somewhat arbitrary and may result in code duplication or unnecessary `for` loops. Combining them is certainly an option. `run_checks_on_output` takes the output of a query and, for each `check` defined in `dbqueries.py`, creates a new column (using the name of the check) of `True` and `False` values by using the pandas Series `map` method with the check's lambda function. Using `map` here may be too fancy and contribute to the code duplication I mentioned, but I wanted to try it out. I then check whether any `False` values occur in the column, adding the color for each check to a `flag_strings` list. The expanded DataFrame and list of flags are then returned as part of a `namedtuple`. `generate_results_text` then takes the `query_name` and the `checked_output_df` and cycles through the rows, creating a neat string representation of the query name, the data, and all instances where checks failed. When a `False` value is found in a row, a label is created with the form "{check name} condition failed". If multiple of these occur for a row, they are joined and then an arrow prefix (" <-- ") is added to the label.

3) Some other changes to the code were made to tie all of this together. The code under "Main Program" passes the relevant data from one function to the next, and then creates a list of flags without duplicates that is used as prefix for the email subject line. Note also that I simply return the `output_df` from `execute_query_and_write_to_csv` rather than re-opening the CSV in later functions, as we were doing before.

4) I also added two tests to ensure that the two functions described in 2. would work as expected (raising flags and modifying the text output) when concerning data (with values failing the given conditions) were passed through them.