### PR TITLE
Adding support for validating UDP Context Store (#15)

### DIFF
--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -1,14 +1,26 @@
 {
     "LOG_LEVEL": "WARNING",
-    "/*  Fill in values for database host, port, name, user, and password!": "*/",
-    "UDW": {
-        "type": "PostgreSQL",
-        "params": {
-            "host": "",
-            "port": "",
-            "dbname": "",
-            "user": "",
-            "password": ""
+    "/*  Fill in values for database host, port, name, user, and password for each data source!": "*/",
+    "DATA_SOURCES" : {
+        "UDW": {
+            "type": "PostgreSQL",
+            "params": {
+                "host": "",
+                "port": "",
+                "dbname": "",
+                "user": "",
+                "password": ""
+            }
+        },
+        "UDP": {
+            "type": "PostgreSQL",
+            "params": {
+                "host": "",
+                "port": "",
+                "dbname": "",
+                "user": "",
+                "password": ""
+            }
         }
     },
     "OUT_DIR": "data/"

--- a/config/env_sample.json
+++ b/config/env_sample.json
@@ -12,7 +12,7 @@
                 "password": ""
             }
         },
-        "UDP": {
+        "UDP Context Store": {
             "type": "PostgreSQL",
             "params": {
                 "host": "",

--- a/dbqueries.py
+++ b/dbqueries.py
@@ -61,5 +61,27 @@ QUERIES = {
                 'rows_to_ignore': []
             }
         }
+    },
+    'udp_context_store_view_counts': {
+        'output_file_name': 'udp_context_store_view_counts.csv',
+        'data_source': 'UDP Context Store',
+        'query_name': 'UDP Context Store View Record Counts',
+        'type': 'table_counts',
+        'tables': [
+            'entity.learner_activity',
+            'entity.course_offering',
+            'entity.course_grade',
+            'entity.academic_term',
+            'entity.annotation',
+            'entity.learner_activity_result',
+            'entity.person',
+        ],
+        'checks': {
+            'not_zero': {
+                'color': 'YELLOW',
+                'condition': (lambda x: x != 0),
+                'rows_to_ignore': []
+            }
+        }
     }
 }

--- a/jobs.py
+++ b/jobs.py
@@ -1,0 +1,25 @@
+# Job configuration for validate.py
+
+# Each key in the dictionary assigned to JOBS should be an abbreviated name for the job. The value should be a
+# dictionary with two key-value pairs: the "full_name" key should have as its value a human-readable string identifying
+# the job; the "queries" key should have as its value a list of query names from dbqueries.py.
+
+JOBS = {
+    "UDW": {
+        "full_name": "UDW Daily Status Report",
+        "queries": [
+            "unizin_metadata",
+            "udw_table_counts",
+            "number_of_courses_by_term"
+        ]
+    },
+    "Unizin": {
+        "full_name": "Unizin Daily Status Report",
+        "queries": [
+            "unizin_metadata",
+            "udw_table_counts",
+            "udp_context_store_view_counts",
+            "number_of_courses_by_term"
+        ]
+    }
+}

--- a/test.py
+++ b/test.py
@@ -38,6 +38,31 @@ class TestFlagRaising(unittest.TestCase):
         result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
         self.assertEqual(result_text.count('<-- "not_zero" condition failed'), 2)
 
+    def test_udp_context_store_view_counts_check(self):
+        # Set up
+        udp_view_counts_df = pd.DataFrame({
+            'table_name': [
+                'entity.learner_activity',
+                'entity.course_offering',
+                'entity.course_grade',
+                'entity.academic_term',
+                'entity.annotation',
+                'entity.learner_activity_result',
+                'entity.person',
+            ],
+            'record_count': [1000, 1000, 0, 1000, 1000, 1000, 1000]
+        })
+        query_dict = QUERIES['udp_context_store_view_counts']
+        # Test
+        checks_result = validate.run_checks_on_output(query_dict['checks'], udp_view_counts_df)
+        self.assertCountEqual(
+            ['table_name', 'record_count', 'not_zero'],
+            checks_result.checked_output_df.columns.to_list()
+        )
+        self.assertTrue(checks_result.flags == ["YELLOW"])
+        result_text = validate.generate_result_text(query_dict['query_name'], checks_result.checked_output_df)
+        self.assertIn('<-- "not_zero" condition failed', result_text)
+
     def test_unizin_metadata_check(self):
         # Set up
         delta_obj = timedelta(days=-3)

--- a/validate.py
+++ b/validate.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
         flags.append("GREEN")
     flag_prefix = f"[{', '.join(flags)}]"
     now = datetime.now(tz=pytz.UTC)
-    print(f"{flag_prefix} {job} for {now:%B %d, %Y}\n\n{results_text}")
+    print(f"{flag_prefix} {job_name} for {now:%B %d, %Y}\n\n{results_text}")
 
     if "RED" in flags:
         logger.error("Status is RED")

--- a/validate.py
+++ b/validate.py
@@ -4,9 +4,10 @@
 
 # Local modules
 from dbqueries import QUERIES
+from jobs import JOBS
 
 # Standard modules
-import json, logging, os, smtplib, sys
+import json, logging, os, sys
 from datetime import datetime
 from collections import namedtuple
 
@@ -122,17 +123,19 @@ def generate_result_text(query_name, checked_query_output_df):
         result_header += f"!! Flagged {total_flags} possible issue(s) !!\n"
     return result_header + result_text
 
+
 # Main Program
 
 if __name__ == "__main__":
-    # Run standard UDW validation process
-    job = "Unizin Daily Status Report"
-    query_keys = [
-        "unizin_metadata",
-        "udw_table_counts",
-        "udp_context_store_view_counts",
-        "number_of_courses_by_term",
-    ]
+    if len(sys.argv) > 1 and sys.argv[1] in JOBS:
+        job_key = sys.argv[1]
+    else:
+        # The default job is the UDW Daily Status Report.
+        job_key = "UDW"
+
+    job = JOBS[job_key]
+    job_name = job["full_name"]
+    query_keys = job["queries"]
 
     results_text = ""
     flags = []

--- a/validate.py
+++ b/validate.py
@@ -126,8 +126,13 @@ def generate_result_text(query_name, checked_query_output_df):
 
 if __name__ == "__main__":
     # Run standard UDW validation process
-    job = "UDW Daily Status Report"
-    query_keys = ["unizin_metadata", "udw_table_counts", "number_of_courses_by_term"]
+    job = "Unizin Daily Status Report"
+    query_keys = [
+        "unizin_metadata",
+        "udw_table_counts",
+        "udp_context_store_view_counts",
+        "number_of_courses_by_term",
+    ]
 
     results_text = ""
     flags = []

--- a/validate.py
+++ b/validate.py
@@ -34,10 +34,11 @@ OUT_DIR = ENV.get("OUT_DIR", "data/")
 
 logger.setLevel(ENV.get("LOG_LEVEL", "DEBUG"))
 
+
 # Functions
 
 def establish_db_connection(db_name):
-    db_config = ENV[db_name]
+    db_config = ENV["DATA_SOURCES"][db_name]
     if db_config['type'] == "PostgreSQL":
         conn = psycopg2.connect(**db_config['params'])
     else:


### PR DESCRIPTION
This PR adds a query, test, and other small modifications to enable connection to the Unizin Data Platform's Context Store and perform record count validation of the tables we have initially identified as relevant to T&L development. Some additional details are provided below. The PR aims to resolve issue #15. 

Specifically, I modified the existing `env.json` structure to have a parent `DATA_SOURCES` variable, which contains a dictionary of all data sources, and then made a small tweak to `establish_db_connection` to look for the parameters in the right place. I then added a new query that @zqian and I worked on together, following the existing `udw_table_counts` query and the crosswalk provided at Unizin's [Canvas to UCDM page](https://docs.udp.unizin.org/ucdm/canvas-to-ucdm.html). I also added a test to ensure the `YELLOW` flag is being raised properly. Some small modifications were made under "Main Program" to include the new query and make the job name more global ("Unizin Daily Status Report").

