### PR TITLE
Bump up Python version to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM directive instructing base image to build upon
-FROM python:3.6
+FROM python:3.7
 
 COPY requirements.txt /requirements.txt
 


### PR DESCRIPTION
This PR upgrades the base image used in the project's `Dockerfile` to Python 3.7 to allow for use of `datetime` module methods only available in 3.7+ (see [datetime docs](https://docs.python.org/3/library/datetime.html)). The PR aims to resolve issue #17.