### PR TITLE
Changing Dockerfile to run validate.py directly (#19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-dev xmlsec1 cron && \
     apt-get clean -y
 
-# COPY startup script into known file location in container
-COPY start.sh /start.sh
-
 WORKDIR /unizin-csv-validation/
 COPY . /unizin-csv-validation/
 
@@ -20,4 +17,6 @@ COPY . /unizin-csv-validation/
 ENV TZ=America/Detroit
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-CMD ["/start.sh"]
+CMD ["python", "validate.py"]
+
+# Done!

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-env
-
-python /unizin-csv-validation/validate.py -o 5


### PR DESCRIPTION
This PR simplifies the execution process by removing the existing `start.sh` script (and mentions of it in the `Dockerfile`) and calling `validate.py` directly in the final `CMD` line. This change also allowed us to delete unnecessary or outdated code from `start.sh`, including an `env` line (that output to the console a bunch of environment variables) and an old command line argument specifying an option (see changes from PR #6 for full context). The PR aims to resolve issue #19.