### PR TITLE
Using local time to determine header date

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -1,5 +1,5 @@
 # validate.py - Unizin Data Warehouse validator
-#
+
 # Copyright (C) 2019 University of Michigan ITS Teaching and Learning
 
 # Local modules
@@ -15,7 +15,7 @@ from collections import namedtuple
 from email.mime.text import MIMEText
 import numpy as np
 import pandas as pd
-import psycopg2, pytz
+import psycopg2
 
 # Global variables
 
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     if len(flags) == 0:
         flags.append("GREEN")
     flag_prefix = f"[{', '.join(flags)}]"
-    now = datetime.now(tz=pytz.UTC)
+    now = datetime.now()
     print(f"{flag_prefix} {job_name} for {now:%B %d, %Y}\n\n{results_text}")
 
     if "RED" in flags:


### PR DESCRIPTION
This PR makes a couple modifications to `validate.py` in order to make the date listed in the header reflect the local time(for our team, Eastern). Previously, `pytz.UTC` was passed to `datetime.now()`; parsing the object resulted in a date that was one day ahead of the local time (the script is run by Jenkins at 10:50-ish EST, and UTC is a handful of hours ahead). To get the date for the local time, we can simply just call `now()` without parameters. I also removed the import for `pytz` (it's still imported in `dbqueries.py`) and un-commented a blank line. The PR aims to resolve issue #22.